### PR TITLE
🏭 Support for factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 All notable changes to this project will be documented in this file.
 
 ### Added
+
+-   ✨ Support your custom factories ([#2](https://github.com/damianpumar/ts-injecty/pull/2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,36 @@
 
 ## New version 🚀
 
-Now we are supporting the constructor parameters
+Now we are supporting factories
+
+```typescript
+// You must extends your custom factories from Factory, and we will inject automatically the resolver in your factory.
+
+export class FactoryImplementation extends Factory {
+    public create(type: "Bar" | "Buzz") {
+        if (type === "Bar") {
+            return this.resolver.resolve(Bar);
+        }
+
+        return this.resolver.resolve(Buzz);
+    }
+}
+
+Container.register([
+    register(Bar).build(),
+    register(Buzz).build(),
+    register(FactoryImplementation).build(),
+]);
+
+const resolved = Container.resolve(FactoryImplementation);
+
+expect(resolved.create("Bar")).toBeInstanceOf(Bar);
+expect(resolved.create("Buzz")).toBeInstanceOf(Buzz);
+```
+
+## Version: 0.0.17
+
+Support the constructor parameters fully typed
 
 ```typescript
 // Now in your IDE you can see the withDependencies, this function is automatically generated only when your class has more than one argument.

--- a/src/__tests__/Container.test.ts
+++ b/src/__tests__/Container.test.ts
@@ -11,6 +11,9 @@ import {
     InnerRoot,
     InnerRootB,
     InterfaceImplementation,
+    Bar,
+    Buzz,
+    FactoryImplementation,
 } from "./fakeClasses";
 
 describe("Container should", () => {
@@ -193,5 +196,18 @@ describe("Container should", () => {
         const resolved2 = Container.resolve(Root);
 
         expect(resolved.innerA.inner).not.toBe(resolved2.innerA.inner);
+    });
+
+    test("Resolve as a factory dependency", () => {
+        Container.register([
+            register(Bar).build(),
+            register(Buzz).build(),
+            register(FactoryImplementation).build(),
+        ]);
+
+        const resolved = Container.resolve(FactoryImplementation);
+
+        expect(resolved.create("Bar")).toBeInstanceOf(Bar);
+        expect(resolved.create("Buzz")).toBeInstanceOf(Buzz);
     });
 });

--- a/src/__tests__/DIContainer.test.ts
+++ b/src/__tests__/DIContainer.test.ts
@@ -119,7 +119,7 @@ describe("DIContainer", () => {
             factory((container) => {
                 return new Promise((resolve) =>
                     setTimeout(() => {
-                        resolve(container.get("dsn"));
+                        resolve(container.resolve("dsn"));
                     })
                 );
             })

--- a/src/__tests__/fakeClasses.ts
+++ b/src/__tests__/fakeClasses.ts
@@ -1,3 +1,5 @@
+import { Factory } from "../Container";
+
 export class Foo {
     public name: string;
     public service: Bar;
@@ -14,12 +16,16 @@ export class Foo {
 }
 
 export class Bar {
+    public bar() {
+        return "bar";
+    }
+}
+
+export class Buzz {
     public buzz() {
         return "buzz";
     }
 }
-
-export class Buzz {}
 
 export abstract class AbstractFoo {
     public name: string;
@@ -107,4 +113,14 @@ export class InnerRootB {
 
 export class InnerDep {
     public value: string = "";
+}
+
+export class FactoryImplementation extends Factory {
+    public create(type: "Bar" | "Buzz") {
+        if (type === "Bar") {
+            return this.resolver.resolve(Bar);
+        }
+
+        return this.resolver.resolve(Buzz);
+    }
 }

--- a/src/container/DIContainer.ts
+++ b/src/container/DIContainer.ts
@@ -7,6 +7,7 @@ import ValueDefinition from "../definitions/ValueDefinition";
 import DependencyIsMissingError from "../errors/DependencyIsMissingError";
 import CircularDependencyError from "../errors/CircularDependencyError";
 import ObjectDefinition from "../definitions/ObjectDefinition";
+import { ResolveArg } from "../types";
 
 interface INamedDefinitions {
     [x: string]: IDefinition | any;
@@ -36,22 +37,10 @@ export default class DIContainer implements IDIContainer {
         return this.resolved[name];
     }
 
-    validateCircularResolution(
-        parentDeps: string[],
-        name: string,
-        definition: IDefinition
-    ) {
-        if (!parentDeps.includes(name)) return;
+    public resolve<T>(type: ResolveArg<T>): T {
+        if (typeof type === "string") return this.get<T>(type);
 
-        if (!(definition instanceof ObjectDefinition)) return;
-
-        if (
-            definition.dependencies.some((dependency) =>
-                parentDeps.includes(dependency)
-            )
-        ) {
-            throw new CircularDependencyError(name, parentDeps);
-        }
+        return this.get<T>(type.name);
     }
 
     public addDefinition(name: string, definition: IDefinition | any) {
@@ -67,5 +56,23 @@ export default class DIContainer implements IDIContainer {
         Object.keys(definitions).map((name: string) => {
             this.addDefinition(name, definitions[name]);
         });
+    }
+
+    private validateCircularResolution(
+        parentDeps: string[],
+        name: string,
+        definition: IDefinition
+    ) {
+        if (!parentDeps.includes(name)) return;
+
+        if (!(definition instanceof ObjectDefinition)) return;
+
+        if (
+            definition.dependencies.some((dependency) =>
+                parentDeps.includes(dependency)
+            )
+        ) {
+            throw new CircularDependencyError(name, parentDeps);
+        }
     }
 }

--- a/src/container/IDIContainer.ts
+++ b/src/container/IDIContainer.ts
@@ -1,3 +1,9 @@
-export interface IDIContainer {
+import { ResolveArg } from "../types";
+
+export interface Resolver {
+    resolve<T>(type: ResolveArg<T>): T;
+}
+
+export interface IDIContainer extends Resolver {
     get: <T>(serviceName: string) => T;
 }

--- a/src/definitions/FactoryDefinition.ts
+++ b/src/definitions/FactoryDefinition.ts
@@ -1,12 +1,12 @@
 import BaseDefinition from "./BaseDefinition";
-import { IDIContainer } from "../container/IDIContainer";
+import { IDIContainer, Resolver } from "../container/IDIContainer";
 import { Mode } from "../types";
 
-export type Factory = (container: IDIContainer) => any;
+export type FactoryType = (container: Resolver) => any;
 
 export default class FactoryDefinition extends BaseDefinition {
-    constructor(private readonly factory: Factory) {
-        super(Mode.SINGLETON);
+    constructor(private readonly factory: FactoryType) {
+        super(Mode.TRANSIENT);
     }
 
     resolve<T>(container: IDIContainer): T {

--- a/src/definitions/__tests__/FactoryDefinition.test.ts
+++ b/src/definitions/__tests__/FactoryDefinition.test.ts
@@ -1,5 +1,5 @@
 import DIContainer from "../../container/DIContainer";
-import { IDIContainer } from "../../container/IDIContainer";
+import { IDIContainer, Resolver } from "../../container/IDIContainer";
 import FactoryDefinition from "../FactoryDefinition";
 import ValueDefinition from "../ValueDefinition";
 
@@ -13,8 +13,8 @@ describe("FactoryDefinition", () => {
     test("it resolves value using values from container", () => {
         const container = new DIContainer();
         container.addDefinition("key1", new ValueDefinition("value1"));
-        const definition = new FactoryDefinition((container: IDIContainer) => {
-            return container.get("key1");
+        const definition = new FactoryDefinition((resolver: Resolver) => {
+            return resolver.resolve("key1");
         });
         expect(definition.resolve(container)).toEqual("value1");
     });
@@ -22,15 +22,13 @@ describe("FactoryDefinition", () => {
     test("it resolves value using async factory", async () => {
         const container = new DIContainer();
         container.addDefinition("key1", new ValueDefinition("value1"));
-        const definition = new FactoryDefinition(
-            async (container: IDIContainer) => {
-                return await new Promise((resolve) =>
-                    setTimeout(() => {
-                        resolve(container.get("key1"));
-                    })
-                );
-            }
-        );
+        const definition = new FactoryDefinition(async (resolver: Resolver) => {
+            return await new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(resolver.resolve("key1"));
+                })
+            );
+        });
 
         expect(await definition.resolve(container)).toEqual("value1");
     });

--- a/src/definitions/__tests__/ObjectDefinition.test.ts
+++ b/src/definitions/__tests__/ObjectDefinition.test.ts
@@ -39,7 +39,7 @@ describe("ObjectDefinition", () => {
         const instance = definition.resolve<Foo>(container);
         expect(instance).toBeInstanceOf(Foo);
         expect(instance.name).toEqual(fakeName);
-        expect(instance.service.buzz()).toEqual("buzz");
+        expect(instance.service.bar()).toEqual("bar");
     });
 
     test("it calls methods after object have been initiated", () => {

--- a/src/definitions/definitionBuilders.ts
+++ b/src/definitions/definitionBuilders.ts
@@ -3,7 +3,7 @@ import { Ref, Mode } from "../types";
 import ObjectDefinition from "./ObjectDefinition";
 import ValueDefinition from "./ValueDefinition";
 import ExistingDefinition from "./ExistingDefinition";
-import FactoryDefinition, { Factory } from "./FactoryDefinition";
+import FactoryDefinition, { FactoryType } from "./FactoryDefinition";
 
 export const object = (ctor: Ref<any>, mode?: Mode) => {
     return new ObjectDefinition(ctor, mode);
@@ -17,6 +17,6 @@ export const get = (name: string) => {
     return new ExistingDefinition(name);
 };
 
-export const factory = (factory: Factory) => {
+export const factory = (factory: FactoryType) => {
     return new FactoryDefinition(factory);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { Container } from "./Container";
+import { Container, Factory } from "./Container";
 import { register } from "./DependencyBuilder";
 import { useResolve } from "./useResolve";
 import { Ref } from "./types";
 
 export default Container;
 
-export { register, useResolve, Ref as Class };
+export { register, useResolve, Factory, Ref as Class };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Resolver } from "./container/IDIContainer";
+
 export enum Mode {
     SINGLETON,
     TRANSIENT,
@@ -142,7 +144,11 @@ type Dependency<R> = Length<ConstructorTypes<R>> extends 1
     : Length<ConstructorTypes<R>> extends 7
     ? SevenDepParams<R>
     : Scope<R>;
-type ClassRegisterType<R> = Dependency<R> & Scope<R> & ClassImplementation<R>;
+
+type Factory<R> = ConstructorTypes<R>[0] extends Resolver ? Build : never;
+type ClassRegisterType<R> =
+    | Factory<R>
+    | (Dependency<R> & Scope<R> & ClassImplementation<R>);
 
 export type RegisterType<R> = R extends string
     ? StringRegisterType<R>


### PR DESCRIPTION

Now we are supporting factories

```typescript
// You must extends your custom factories from Factory, and we will inject automatically the resolver in your factory.

export class FactoryImplementation extends Factory {
    public create(type: "Bar" | "Buzz") {
        if (type === "Bar") {
            return this.resolver.resolve(Bar);
        }

        return this.resolver.resolve(Buzz);
    }
}

Container.register([
    register(Bar).build(),
    register(Buzz).build(),
    register(FactoryImplementation).build(),
]);

const resolved = Container.resolve(FactoryImplementation);

expect(resolved.create("Bar")).toBeInstanceOf(Bar);
expect(resolved.create("Buzz")).toBeInstanceOf(Buzz);